### PR TITLE
Fix Dockerfile

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:16.04
 MAINTAINER John L. Singleton <jls@cs.ucf.edu>
 # base setup stuff
-RUN echo "Acquire::http::Proxy \"http://florence.eecs.ucf.edu:3142\";" > /etc/apt/apt.conf.d/02proxy
 RUN apt-get update && apt-get install -y openjdk-8-jdk build-essential python
 # create the needed directories
 RUN mkdir /tools/


### PR DESCRIPTION
The dockerfile works perfectly without the proxy.
The proxy is no longer reachable, causing error in the docker building process.
Removing it I was able to make the docker work.

The screenshot below show the error using the proxy
<img width="1428" alt="Screenshot 2019-12-07 at 11 21 14" src="https://user-images.githubusercontent.com/36055796/70372786-e2cdc380-18e3-11ea-87e9-697c4e629378.png">
